### PR TITLE
chore: add renovate configuration for automated dependency management

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,29 @@
+{
+	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	"dependencyDashboard": true,
+	"lockFileMaintenance": { "enabled": true },
+	"schedule": ["before 5am on friday"],
+	"timezone": "Europe/Berlin",
+	"packageRules": [
+		{
+			"description": "Group (minor) Python package updates into single PRs",
+			"groupName": "pipenv",
+			"automerge": true,
+			"matchUpdateTypes": ["minor", "patch", "lockFileMaintenance"],
+			"matchManagers": ["pipenv"]
+		},
+		{
+			"description": "Group (minor) Node package updates into single PRs",
+			"groupName": "node",
+			"automerge": true,
+			"matchUpdateTypes": ["minor", "patch", "lockFileMaintenance"],
+			"matchManagers": ["npm"]
+		},
+		{
+			"description": "Auto-merge updates for Docker & 'pre-commit'",
+			"automerge": true,
+			"matchUpdateTypes": ["minor", "patch", "digest"],
+			"matchManagers": ["dockerfile", "pre-commit"]
+		}
+	]
+}


### PR DESCRIPTION
This will be great after Norman merges https://github.com/ZeitOnline/renovate-deployment/pull/96 