### PR TITLE
feat: add further validation for CSV games (Wortiger)

### DIFF
--- a/app/src/components/CSVGameFileUploader.svelte
+++ b/app/src/components/CSVGameFileUploader.svelte
@@ -4,7 +4,7 @@
   import Papa from 'papaparse';
   import { dev } from '$app/environment';
   import ViewNavigation from './ViewNavigation.svelte';
-  import { zodClient } from 'sveltekit-superforms/adapters';
+  import { zodClient, type ZodObjectType } from 'sveltekit-superforms/adapters';
   import { ERRORS } from '$lib/error-messages';
   import { APP_MESSAGES } from '$lib/app-messages';
   import { CONFIG_GAMES } from '$config/games.config';
@@ -42,9 +42,11 @@
   let isDragging = $state(false);
   let fileInput = $state<HTMLInputElement | null>(null);
 
+  const generateGameSchema = CONFIG_GAMES[gameName].schemas.generateGameSchema as unknown as ZodObjectType;
+
   const { form, errors, enhance, isTainted, reset } = superForm(data.generateGameForm, {
     resetForm: false,
-    validators: zodClient(CONFIG_GAMES[gameName].schemas.generateGameSchema),
+    validators: zodClient(generateGameSchema),
     SPA: true,
     taintedMessage: true,
     invalidateAll: false,

--- a/app/src/components/games/wortiger/WortigerBulkEditor.svelte
+++ b/app/src/components/games/wortiger/WortigerBulkEditor.svelte
@@ -59,7 +59,9 @@
       const entry = idx[len].get(key) ?? { count: 0, first_date: undefined };
       entry.count += 1;
       // keep the earliest date we see for nicer messaging (optional)
-      if (g?.release_date && !entry.first_date) entry.first_date = g.release_date;
+      if (g?.release_date && !entry.first_date) {
+        entry.first_date = g.release_date;
+      }
       idx[len].set(key, entry);
     }
     return idx;
@@ -70,7 +72,9 @@
     for (const g of data.games) {
       if (!isWortigerGame(g)) continue;
 
-      if (g.release_date) s.add(g.release_date.slice(0, 10));
+      if (g.release_date) {
+        s.add(g.release_date.slice(0, 10));
+      }
     }
     return s;
   });
@@ -109,7 +113,9 @@
     let i = 0;
     while (data[i] !== undefined) {
       const w = data[i]?.word;
-      if (w) set.add(normalize(w));
+      if (w) {
+        set.add(normalize(w));
+      }
       i++;
     }
     return set;

--- a/app/src/routes/eckchen/+page.ts
+++ b/app/src/routes/eckchen/+page.ts
@@ -18,19 +18,14 @@ export const load = async (): Promise<{
   saveGameForm: SaveGameForm;
   games: GameComplete[];
 }> => {
-
   const { schemas } = CONFIG_GAMES.eckchen;
 
   const generateGameSchema = schemas.generateGameSchema;
   const saveGameFormSchema = schemas.saveGameFormSchema;
 
   // The two forms are handled here based on current game configuration
-  const generateGameForm = (await superValidate(
-    zod4(generateGameSchema),
-  )) as GenerateGameForm;
-  const saveGameForm = (await superValidate(
-    zod4(saveGameFormSchema),
-  )) as SaveGameForm;
+  const generateGameForm = (await superValidate(zod4(generateGameSchema))) as GenerateGameForm;
+  const saveGameForm = (await superValidate(zod4(saveGameFormSchema))) as SaveGameForm;
 
   const games = await getAllGames({ gameName: 'eckchen' });
 

--- a/app/src/routes/wortiger/+page.ts
+++ b/app/src/routes/wortiger/+page.ts
@@ -23,12 +23,8 @@ export const load = async (): Promise<{
   const generateGameSchema = schemas.generateGameSchema;
   const saveGameFormSchema = schemas.saveGameFormSchema;
 
-  const generateGameForm = (await superValidate(
-    zod4(generateGameSchema),
-  )) as GenerateGameForm;
-  const saveGameForm = (await superValidate(
-    zod4(saveGameFormSchema),
-  )) as SaveGameForm;
+  const generateGameForm = (await superValidate(zod4(generateGameSchema))) as GenerateGameForm;
+  const saveGameForm = (await superValidate(zod4(saveGameFormSchema))) as SaveGameForm;
 
   const games = await getAllGames({ gameName: 'wortiger' });
 

--- a/app/src/types/index.ts
+++ b/app/src/types/index.ts
@@ -52,6 +52,8 @@ export type GameWortigerComplete = GameWortiger & {
 };
 
 export type DataProps = {
+  games: GameComplete[];
+  saveGameForm: SuperValidated<GameEckchen | GameWortiger>;
   generateGameForm: SuperValidated<{
     csv: File;
   }>;

--- a/app/src/views/DashboardView.svelte
+++ b/app/src/views/DashboardView.svelte
@@ -11,7 +11,6 @@
 		store.updateView('new-game');
 	}
 
-	// console.log('The games in the dashboard:', games)
 </script>
 
 <ViewWrapper>

--- a/app/src/views/NewGameView.svelte
+++ b/app/src/views/NewGameView.svelte
@@ -73,6 +73,7 @@
       {:else if gameName === 'wortiger'}
 	    <!-- Wortiger allows a bulk upload from the csv directly into the db -->
         <WortigerBulkEditor
+          {data}
           {store}
           bind:beginning_option
           bind:resultsDataBody


### PR DESCRIPTION
Ticket:
https://zeit-online.atlassian.net/browse/GAMES-208

We are adding now two more validations:
- Is the game solution (for the 4, 5, 6, 7 riddles) already used before at any other datum?
- is the datum already used before. In that case, we want to avoid submitting since we push all the games for a day directly

<img width="986" height="568" alt="Screenshot 2025-09-30 at 14 04 42" src="https://github.com/user-attachments/assets/28fd2bdc-a33d-4083-a416-23f4fecacfd9" />
