### PR TITLE
feat: use auth header directly on api requests

### DIFF
--- a/app/src/lib/postgrest-client.ts
+++ b/app/src/lib/postgrest-client.ts
@@ -196,7 +196,7 @@ export const requestPostgrest = async <TResponse, TBody = unknown>({
   }
 
   if (oidc?.accessToken) {
-    requestHeaders.set('X-API-Token', oidc.accessToken);
+    requestHeaders.set('Authorization', `Bearer ${oidc.accessToken}`);
   }
 
   const response = await fetchFn(finalUrl, {

--- a/app/src/views/NewGameView.svelte
+++ b/app/src/views/NewGameView.svelte
@@ -60,8 +60,8 @@
     />
     <div class="flex items-center justify-between gap-z-ds-8">
       {#each ACTIONS as action (action.name)}
+          <!-- add hidden if action.name === 'csv' && !canCSV -->
         <button
-          // add hidden if action.name === 'csv' && !canCSV
           class={[
             'relative flex-1 z-ds-button z-ds-button-outline flex items-center min-h-50 text-sm',
             action.name === 'csv' && !canCSV ? 'hidden!' : '',


### PR DESCRIPTION
### Ticket

Gibt es nicht

### Description

Dass wir das access token als eigenen Header übergeben war eine Krücke, die wir nicht mehr brauchen. Sobald das auf staging funktioniert kann ich im spiele-deployment repo etwas Logik entfernen.

